### PR TITLE
Bring back ODBC

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ require 'openssl'
 source 'https://rubygems.org'
 gemspec
 
-gem 'sqlite3'
+gem 'sqlite3', '< 1.4'
 gem 'minitest', '< 5.3.4'
 gem 'bcrypt'
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
@@ -49,6 +49,10 @@ group :tinytds do
   else
     gem 'tiny_tds'
   end
+end
+
+group :odbc do
+  gem 'ruby-odbc', :git => 'https://github.com/cloudvolumes/ruby-odbc.git', :tag => '0.101.cv'
 end
 
 group :development do

--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ task default: [:test]
 
 namespace :test do
 
-  %w(dblib).each do |mode|
+  %w(dblib odbc).each do |mode|
 
     Rake::TestTask.new(mode) do |t|
       t.libs = ARTest::SQLServer.test_load_paths
@@ -23,12 +23,17 @@ namespace :test do
     ENV['ARCONN'] = 'dblib'
   end
 
+  task 'odbc:env' do
+    ENV['ARCONN'] = 'odbc'
+  end
+
 end
 
 task 'test:dblib' => 'test:dblib:env'
+task 'test:odbc' => 'test:odbc:env'
 
 namespace :profile do
-  ['dblib'].each do |mode|
+  ['dblib', 'odbc'].each do |mode|
     namespace mode.to_sym do
       Dir.glob('test/profile/*_profile_case.rb').sort.each do |test_file|
         profile_case = File.basename(test_file).sub('_profile_case.rb', '')

--- a/lib/active_record/connection_adapters/sqlserver/core_ext/odbc.rb
+++ b/lib/active_record/connection_adapters/sqlserver/core_ext/odbc.rb
@@ -1,0 +1,34 @@
+module ActiveRecord
+  module ConnectionAdapters
+    module SQLServer
+      module CoreExt
+        module ODBC
+
+          module Statement
+
+            def finished?
+              connected?
+              false
+            rescue ::ODBC::Error
+              true
+            end
+
+          end
+
+          module Database
+
+            def run_block(*args)
+              yield sth = run(*args)
+              sth.drop
+            end
+
+          end
+
+        end
+      end
+    end
+  end
+end
+
+ODBC::Statement.send :include, ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::ODBC::Statement
+ODBC::Database.send :include, ActiveRecord::ConnectionAdapters::SQLServer::CoreExt::ODBC::Database

--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -112,6 +112,18 @@ module ActiveRecord
                 yield(r) if block_given?
               end
               result.each.map { |row| row.is_a?(Hash) ? row.with_indifferent_access : row }
+            when :odbc
+              results = []
+              raw_connection_run(sql) do |handle|
+                get_rows = lambda do
+                  rows = handle_to_names_and_values handle, fetch: :all
+                  rows.each_with_index { |r, i| rows[i] = r.with_indifferent_access }
+                  results << rows
+                end
+                get_rows.call
+                get_rows.call while handle_more_results?(handle)
+              end
+              results.many? ? results : results.first
             end
           end
         end
@@ -276,6 +288,8 @@ module ActiveRecord
           case @connection_options[:mode]
           when :dblib
             @connection.execute(sql).do
+          when :odbc
+            @connection.do(sql)
           end
         ensure
           @update_sql = false
@@ -322,12 +336,16 @@ module ActiveRecord
           case @connection_options[:mode]
           when :dblib
             @connection.execute(sql)
+          when :odbc
+            block_given? ? @connection.run_block(sql) { |handle| yield(handle) } : @connection.run(sql)
           end
         end
 
         def handle_more_results?(handle)
           case @connection_options[:mode]
           when :dblib
+          when :odbc
+            handle.more_results
           end
         end
 
@@ -335,6 +353,8 @@ module ActiveRecord
           case @connection_options[:mode]
           when :dblib
             handle_to_names_and_values_dblib(handle, options)
+          when :odbc
+            handle_to_names_and_values_odbc(handle, options)
           end
         end
 
@@ -348,10 +368,28 @@ module ActiveRecord
           options[:ar_result] ? ActiveRecord::Result.new(columns, results) : results
         end
 
+        def handle_to_names_and_values_odbc(handle, options = {})
+          @connection.use_utc = ActiveRecord::Base.default_timezone == :utc
+          if options[:ar_result]
+            columns = lowercase_schema_reflection ? handle.columns(true).map { |c| c.name.downcase } : handle.columns(true).map { |c| c.name }
+            rows = handle.fetch_all || []
+            ActiveRecord::Result.new(columns, rows)
+          else
+            case options[:fetch]
+            when :all
+              handle.each_hash || []
+            when :rows
+              handle.fetch_all || []
+            end
+          end
+        end
+
         def finish_statement_handle(handle)
           case @connection_options[:mode]
           when :dblib
             handle.cancel if handle
+          when :odbc
+            handle.drop if handle && handle.respond_to?(:drop) && !handle.finished?
           end
           handle
         end

--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -174,6 +174,8 @@ module ActiveRecord
         case @connection_options[:mode]
         when :dblib
           @connection.close rescue nil
+        when :odbc
+          @connection.disconnect rescue nil
         end
         @connection = nil
         @spid = nil
@@ -339,6 +341,8 @@ module ActiveRecord
         @connection = case config[:mode]
                       when :dblib
                         dblib_connect(config)
+                      when :odbc
+                        odbc_connect(config)
                       end
         @spid = _raw_select('SELECT @@SPID', fetch: :rows).first.first
         @version_year = version_year
@@ -348,6 +352,7 @@ module ActiveRecord
       def connection_errors
         @connection_errors ||= [].tap do |errors|
           errors << TinyTds::Error if defined?(TinyTds::Error)
+          errors << ODBC::Error if defined?(ODBC::Error)
         end
       end
 
@@ -380,6 +385,25 @@ module ActiveRecord
           client.execute('SET IMPLICIT_TRANSACTIONS OFF').do
           client.execute('SET TEXTSIZE 2147483647').do
           client.execute('SET CONCAT_NULL_YIELDS_NULL ON').do
+        end
+      end
+
+      def odbc_connect(config)
+        if config[:dsn].include?(';')
+          driver = ODBC::Driver.new.tap do |d|
+            d.name = config[:dsn_name] || 'Driver1'
+            d.attrs = config[:dsn].split(';').map { |atr| atr.split('=') }.reject { |kv| kv.size != 2 }.reduce({}) { |a, e| k, v = e ; a[k] = v ; a }
+          end
+          ODBC::Database.new.drvconnect(driver)
+        else
+          ODBC.connect config[:dsn], config[:username], config[:password]
+        end.tap do |c|
+          begin
+            c.use_time = true
+            c.use_utc = ActiveRecord::Base.default_timezone == :utc
+          rescue Exception
+            warn 'Ruby ODBC v0.99992 or higher is required.'
+          end
         end
       end
 

--- a/lib/active_record/sqlserver_base.rb
+++ b/lib/active_record/sqlserver_base.rb
@@ -7,6 +7,10 @@ module ActiveRecord
       case mode
       when :dblib
         require 'tiny_tds'
+      when :odbc
+        raise ArgumentError, 'Missing :dsn configuration.' unless config.key?(:dsn)
+        require 'odbc'
+        require 'active_record/connection_adapters/sqlserver/core_ext/odbc'
       else
         raise ArgumentError, "Unknown connection mode in #{config.inspect}."
       end

--- a/test/cases/adapter_test_sqlserver.rb
+++ b/test/cases/adapter_test_sqlserver.rb
@@ -17,7 +17,7 @@ class AdapterTestSQLServer < ActiveRecord::TestCase
     string = connection.inspect
     string.must_match %r{ActiveRecord::ConnectionAdapters::SQLServerAdapter}
     string.must_match %r{version\: \d.\d}
-    string.must_match %r{mode: dblib}
+    string.must_match %r{mode: (dblib|odbc)}
     string.must_match %r{azure: (true|false)}
     string.wont_match %r{host}
     string.wont_match %r{password}

--- a/test/cases/connection_test_sqlserver.rb
+++ b/test/cases/connection_test_sqlserver.rb
@@ -33,6 +33,61 @@ class ConnectionTestSQLServer < ActiveRecord::TestCase
     end
   end unless connection_sqlserver_azure?
 
+  describe 'ODBC connection management' do
+
+    it 'return finished ODBC statement handle from #execute without block' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.execute('SELECT * FROM [topics]')
+      end
+    end
+
+    it 'finish ODBC statement handle from #execute with block' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.execute('SELECT * FROM [topics]') { }
+      end
+    end
+
+    it 'finish connection from #raw_select' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.send(:raw_select,'SELECT * FROM [topics]')
+      end
+    end
+
+    it 'execute without block closes statement' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.execute("SELECT 1")
+      end
+    end
+
+    it 'execute with block closes statement' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.execute("SELECT 1") do |sth|
+          assert !sth.finished?, "Statement should still be alive within block"
+        end
+      end
+    end
+
+    it 'insert with identity closes statement' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.exec_insert "INSERT INTO accounts ([id],[firm_id],[credit_limit]) VALUES (999, 1, 50)", "SQL", []
+      end
+    end
+
+    it 'insert without identity closes statement' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.exec_insert "INSERT INTO accounts ([firm_id],[credit_limit]) VALUES (1, 50)", "SQL", []
+      end
+    end
+
+    it 'active closes statement' do
+      assert_all_odbc_statements_used_are_closed do
+        connection.active?
+      end
+    end
+
+  end if connection_odbc?
+
+
   describe 'Connection management' do
 
     it 'set spid on connect' do
@@ -65,7 +120,25 @@ class ConnectionTestSQLServer < ActiveRecord::TestCase
     case connection_options[:mode]
     when :dblib
       connection.raw_connection.close rescue nil
+    when :odbc
+      connection.raw_connection.disconnect rescue nil
     end
+  end
+
+  def assert_all_odbc_statements_used_are_closed(&block)
+    odbc = connection.raw_connection.class.parent
+    existing_handles = []
+    ObjectSpace.each_object(odbc::Statement) { |h| existing_handles << h }
+    existing_handle_ids = existing_handles.map(&:object_id)
+    assert existing_handles.all?(&:finished?), "Somewhere before the block some statements were not closed"
+    GC.disable
+    yield
+    used_handles = []
+    ObjectSpace.each_object(odbc::Statement) { |h| used_handles << h unless existing_handle_ids.include?(h.object_id) }
+    assert used_handles.size > 0, "No statements were used within given block"
+    assert used_handles.all?(&:finished?), "Statement should have been closed within given block"
+  ensure
+    GC.enable
   end
 
 end

--- a/test/config.yml
+++ b/test/config.yml
@@ -29,3 +29,12 @@ connections:
       azure: <%= !ENV['ACTIVERECORD_UNITTEST_AZURE'].nil? %>
       timeout: <%= ENV['ACTIVERECORD_UNITTEST_AZURE'].present? ? 20 : nil %>
 
+  odbc:
+    arunit:
+      <<: *default_connection_info
+      dsn: <%= ENV['ACTIVERECORD_UNITTEST_DSN'] || 'activerecord_unittest' %>
+    arunit2:
+      <<: *default_connection_info
+      database: activerecord_unittest2
+      dsn: <%= ENV['ACTIVERECORD_UNITTEST2_DSN'] || 'activerecord_unittest2' %>
+

--- a/test/support/connection_reflection.rb
+++ b/test/support/connection_reflection.rb
@@ -24,6 +24,10 @@ module ARTest
         rc.respond_to?(:tds_73?) && rc.tds_73?
       end
 
+      def connection_odbc?
+        connection_options[:mode] == :odbc
+      end
+
       def connection_sqlserver_azure?
         connection.sqlserver_azure?
       end


### PR DESCRIPTION
ActiveRecord SQLServer Adapter defaults to TinyTDS. And the support for
ODBC had been removed. This is the effort to support Adapter with ODBC
Driver again.

- ruby-odbc is now pointed to https://github.com/cloudvolumes/ruby-odbc
- restricted sqlite3 version to < 1.4