### PR TITLE
Fix ActiveRecord SQLServer adapter to work with the utf8 version of the Ruby::ODBC module

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -28,13 +28,11 @@ module ActiveRecord
         end
 
         def exec_delete(sql, name, binds)
-          sql << '; SELECT @@ROWCOUNT AS AffectedRows'
-          super.rows.first.first
+          super.rows.first.try(:first) || super("SELECT @@ROWCOUNT As AffectedRows", "", []).rows.first.try(:first)
         end
 
         def exec_update(sql, name, binds)
-          sql << '; SELECT @@ROWCOUNT AS AffectedRows'
-          super.rows.first.first
+          super.rows.first.try(:first) || super("SELECT @@ROWCOUNT As AffectedRows", "", []).rows.first.try(:first)
         end
 
         def supports_statement_cache?


### PR DESCRIPTION
Fix ActiveRecord SQLServer adapter to work with the utf8 version of the Ruby::ODBC module

- The UTF8 version does not appear to support multiple statements in a single query. So things like "query; SELECT @@ROWCOUNT" do not work