### PR TITLE
fix typerror no implicit conversion of string into integer

### DIFF
--- a/test/cases/migration_test_sqlserver.rb
+++ b/test/cases/migration_test_sqlserver.rb
@@ -45,7 +45,7 @@ class MigrationTestSQLServer < ActiveRecord::TestCase
 
     it 'not drop the default contraint if just renaming' do
       find_default = lambda do
-        connection.execute_procedure(:sp_helpconstraint, 'sst_string_defaults', 'nomsg').select do |row|
+        connection.execute_procedure(:sp_helpconstraint, 'sst_string_defaults', 'nomsg').flatten.select do |row|
           row['constraint_type'] == "DEFAULT on column string_with_pretend_paren_three"
         end.last
       end


### PR DESCRIPTION
- Error found: MigrationTestSQLServer::For changing column#test_0002_not drop the default contraint if just renaming: TypeError: no implicit conversion of String into Integer
- array needs to be flattened before calling select method