### PR TITLE
Fix date comparison failures by having sqlserver default date set to 1900-01-01

### DIFF
--- a/test/cases/column_test_sqlserver.rb
+++ b/test/cases/column_test_sqlserver.rb
@@ -273,8 +273,8 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       col.sql_type.must_equal           'date'
       col.type.must_equal               :date
       col.null.must_equal               true
-      col.default.must_equal            connection_dblib_73? ? Date.civil(0001, 1, 1) : '0001-01-01'
-      obj.date.must_equal               Date.civil(0001, 1, 1)
+      col.default.must_equal            Date.civil(1900, 1, 1)
+      obj.date.must_equal               Date.civil(1900, 1, 1)
       col.default_function.must_be_nil
       type = connection.lookup_cast_type_from_column(col)
       type.must_be_instance_of          Type::Date
@@ -282,19 +282,19 @@ class ColumnTestSQLServer < ActiveRecord::TestCase
       type.precision.must_be_nil
       type.scale.must_be_nil
       # Can cast strings. SQL Server format.
-      obj.date = '04-01-0001'
-      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.date = '04-01-1900'
+      obj.date.must_equal               Date.civil(1900, 4, 1)
       obj.save!
-      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.date.must_equal               Date.civil(1900, 4, 1)
       obj.reload
-      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.date.must_equal               Date.civil(1900, 4, 1)
       # Can cast strings. ISO format.
-      obj.date = '0001-04-01'
-      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.date = '1900-04-01'
+      obj.date.must_equal               Date.civil(1900, 4, 1)
       obj.save!
-      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.date.must_equal               Date.civil(1900, 4, 1)
       obj.reload
-      obj.date.must_equal               Date.civil(0001, 4, 1)
+      obj.date.must_equal               Date.civil(1900, 4, 1)
       # Can keep and return assigned date.
       assert_obj_set_and_save :date, Date.civil(1972, 04, 14)
       # Can accept and cast time objects.

--- a/test/cases/schema_dumper_test_sqlserver.rb
+++ b/test/cases/schema_dumper_test_sqlserver.rb
@@ -23,7 +23,7 @@ class SchemaDumperTestSQLServer < ActiveRecord::TestCase
     assert_line :float,             type: 'float',        limit: nil,           precision: nil,   scale: nil,  default: 123.00000001
     assert_line :real,              type: 'real',         limit: nil,           precision: nil,   scale: nil,  default: 123.45
     # Date and Time
-    assert_line :date,              type: 'date',         limit: nil,           precision: nil,   scale: nil,  default: "01-01-0001"
+    assert_line :date,              type: 'date',         limit: nil,           precision: nil,   scale: nil,  default: "01-01-1900"
     assert_line :datetime,          type: 'datetime',     limit: nil,           precision: nil,   scale: nil,  default: "01-01-1753 00:00:00.123"
     if connection_dblib_73?
     assert_line :datetime2_7,       type: 'datetime',     limit: nil,           precision: 7,     scale: nil,  default: "12-31-9999 23:59:59.9999999"

--- a/test/schema/datatypes/2012.sql
+++ b/test/schema/datatypes/2012.sql
@@ -23,7 +23,7 @@ CREATE TABLE [sst_datatypes] (
   [float] [float] NULL DEFAULT 123.00000001,
   [real] [real] NULL DEFAULT 123.45,
   -- Date and Time
-  [date] [date] NULL DEFAULT '0001-01-01',
+  [date] [date] NULL DEFAULT '1900-01-01',
   [datetime] [datetime] NULL DEFAULT '1753-01-01T00:00:00.123',
   [datetime2_7] [datetime2](7) NULL DEFAULT '9999-12-31 23:59:59.9999999',
   [datetime2_3] [datetime2](3) NULL,


### PR DESCRIPTION
- SQLserver uses 1900-01-01 as default date instead of current date
- Reference: https://docs.microsoft.com/en-us/sql/relational-databases/native-client-odbc-date-time/datetime-data-type-conversions-from-sql-to-c?view=sql-server-2017