### PR TITLE
Fix String or Binary data truncation error

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver_adapter.rb
+++ b/lib/active_record/connection_adapters/sqlserver_adapter.rb
@@ -1,5 +1,6 @@
 require 'base64'
 require 'active_record'
+require 'odbc_utf8'
 require 'arel_sqlserver'
 require 'active_record/connection_adapters/abstract_adapter'
 require 'active_record/connection_adapters/sqlserver/core_ext/active_record'


### PR DESCRIPTION
- Error found: ActiveRecord::ValueTooLong: ODBC::Error: 22001 (8152)[Microsoft][ODBC Driver 17 for SQL Server][SQL Server]String or binary data would be truncated.
- Require odbc_utf8 so that  UTF-8 variant of the module is in use, and string data is automatically converted to/from Unicode