### PR TITLE
Force data from a binary column type in SQLServer adapter to be treated as binary / ASCII-8Bit

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/type/binary.rb
+++ b/lib/active_record/connection_adapters/sqlserver/type/binary.rb
@@ -4,6 +4,14 @@ module ActiveRecord
       module Type
         class Binary < ActiveRecord::Type::Binary
 
+          def cast_value(value)
+            if value.class.to_s == 'String' and !value.frozen?
+              value.force_encoding(Encoding::BINARY) =~ /[^[:xdigit:]]/ ? value : [value].pack('H*')
+            else
+              value
+            end
+          end
+
           def type
             :binary_basic
           end


### PR DESCRIPTION
Force data from a binary column type in SQLServer adapter to be treated as binary / ASCII-8Bit

- Added a check to make sure the object is String. ActiveRecord tests passes objects which are other than String.
- Added a check to make sure we are not modifying the frozen object. There are tests which passes frozen objects.