### PR TITLE
Remove tiny_tds dependency from activerecord-sqlserver-adpater

### DIFF
--- a/activerecord-sqlserver-adapter.gemspec
+++ b/activerecord-sqlserver-adapter.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
   spec.add_dependency 'activerecord', '~> 5.0.0'
-  spec.add_dependency 'tiny_tds'
+  spec.add_dependency 'ruby-odbc'
 end


### PR DESCRIPTION
- TinyTDS gem for windows is compiled with OpenSSL with a version that has vulnerabilities
- Updating to use ruby-odbc as dependency, as this forked repository is for connecting to SQLServer in ODBC mode