### PR TITLE
Fix trigger_test_sqlserver test case failure

### DIFF
--- a/lib/active_record/connection_adapters/sqlserver/database_statements.rb
+++ b/lib/active_record/connection_adapters/sqlserver/database_statements.rb
@@ -208,9 +208,11 @@ module ActiveRecord
                   if exclude_output_inserted
                     id_sql_type = exclude_output_inserted.is_a?(TrueClass) ? 'bigint' : exclude_output_inserted
                     <<-SQL.strip_heredoc
+                      SET NOCOUNT ON
                       DECLARE @ssaIdInsertTable table (#{quoted_pk} #{id_sql_type});
                       #{sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk} INTO @ssaIdInsertTable"}
-                      SELECT CAST(#{quoted_pk} AS #{id_sql_type}) FROM @ssaIdInsertTable
+                      SELECT CAST(#{quoted_pk} AS #{id_sql_type}) FROM @ssaIdInsertTable;
+                      SET NOCOUNT OFF
                     SQL
                   else
                     sql.dup.insert sql.index(/ (DEFAULT )?VALUES/), " OUTPUT INSERTED.#{quoted_pk}"


### PR DESCRIPTION
- use SET NOCOUNT ON so that the number of rows affected by INSERT
  statement is returned instead of the number of rows affected by the trigger
- Refer https://techcommunity.microsoft.com/t5/SQL-Server/UPDATE-with-OUTPUT-clause-8211-Triggers-8211-and-SQLMoreResults/ba-p/383457

https://confluence.eng.vmware.com/display/RT/Rails+Upgrade+4.2+to+5.0+with+ActiveRecord+SQLServer+Adapter+supporting+ODBC